### PR TITLE
Add spatial extent to search

### DIFF
--- a/ckanext/grouphierarchy/templates/package/read.html
+++ b/ckanext/grouphierarchy/templates/package/read.html
@@ -1,6 +1,5 @@
 {% ckan_extends %}
 
-{
   {% block package_description %}
   {% block package_markers %}
 

--- a/ckanext/grouphierarchy/templates/package/search.html
+++ b/ckanext/grouphierarchy/templates/package/search.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+
+  {% snippet "spatial/snippets/spatial_query.html", default_extent="[[47.8390,10.1403],[50.1734,13.2605]]" %}
+
+  {{ super() }}
+
+{% endblock %}

--- a/ckanext/grouphierarchy/templates/scheming/form_snippets/group.html
+++ b/ckanext/grouphierarchy/templates/scheming/form_snippets/group.html
@@ -1,0 +1,241 @@
+
+{% import 'macros/form.html' as form %}
+
+<hr>
+
+<script>
+
+function show_checkboxes(a, show_checkboxes_after_checking=true){
+
+	// get the currently selected group-name from the activated dropdown
+	var selected_value = a.parentNode.childNodes[1].childNodes[0].childNodes[1].innerText;
+	
+	// get all checkboxes on the page
+	var checkboxes = document.querySelectorAll("[type=checkbox]");
+	
+	// iterate over all checkboxes
+	for(var i = 0; i < checkboxes.length; i++){
+	
+		// only do stuff with checkboxes that are related to the groups, not other checkboses from other scheming parts
+		if(checkboxes[i].id.includes("field-group-")){
+
+			// uncheck the main-category checkboxes so only one main category is checked
+			if(!show_checkboxes_after_checking && parseInt(checkboxes[i].id.split("group-")[1]) < 100){
+				checkboxes[i].checked = false;
+			}
+			
+			// check the checkbox that has the matching name
+			if(checkboxes[i].parentNode.innerText.includes(selected_value)){
+				checkboxes[i].checked = true;
+				
+				// make that checkbox visible (dont make it visible for main-categories)
+				if(show_checkboxes_after_checking){
+					checkboxes[i].parentNode.style.display = "block";
+				}
+			}
+		}
+	}
+}
+</script>
+
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required">*</span>Gruppen bearbeiten</label>
+ <br><br><ol>
+{# Check if it is in editing mode or new dataset mode. This is kinda obsolete, but maybe in the future some text changes should be added. Right now it works as it is, don't want to change it #}
+{% if data.groups %}
+
+	{# Jinja is kind of a weird language that does not allow modifying variables in for / if loops, so this workaround using the group ids and array searches is used. Also Jinja does not allow the 'append' function inside {% ... %}, so I put it inside a html tag that is not visible. #}
+	{% set main_groups_ids = [] %}
+	{% for group in h.get_allowable_children_groups('main-categories') %}
+		<label class="control-label" for="field-group" style="display:none"><span title="abc" class="control-required"></span>{{ main_groups_ids.append(group.id) }}</label>
+	{%endfor %}
+	{% set data_groups_ids = [] %}
+	{% for group in data.groups %}
+		<label class="control-label" for="field-group" style="display:none"><span title="abc" class="control-required"></span>{{ data_groups_ids.append(group.id) }}</label>
+	{%endfor %}
+
+
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required">* </span>Hauptkategorien</label>
+		{% for group in h.get_allowable_children_groups('main-categories') %}
+		{% if group.id in data_groups_ids %}
+			<label class="checkbox" for="field-group-{{ loop.index0 + 20 }}" style="display:none">
+				<input id="field-group-{{ loop.index0 + 20 }}" type="checkbox" name="groups__{{ loop.index0 + 20 }}__id" value="{{ group.id }}" checked=true/>{{ group.title }}
+			</label>
+		{% else %}
+			<label class="checkbox" for="field-group-{{ loop.index0 + 20 }}" style="display:none">
+				<input id="field-group-{{ loop.index0 + 20 }}" type="checkbox" name="groups__{{ loop.index0 + 20 }}__id" value="{{ group.id }}"/>{{ group.title }}
+			</label>
+		{% endif %}
+	{% endfor %}
+
+		
+	{# This would produce multiple drop-down bars, but since there can only be one main category, we are fine. Still really bad coding, but I don't know how to do it better in Jinja. #}
+	{% for group in data.groups %}
+		{%if group.id in main_groups_ids %}
+			<div class="controls">
+				<select id="field-group_1" name="groups__0__id" data-module="autocomplete" onclick="show_checkboxes(this, false)">
+					<option value="{{ group.id }}" >{{ group.title }}</option>
+					{% for group_iter in h.get_allowable_children_groups('main-categories')  %}
+						{% if group_iter.id != group.id %}
+							<option value="{{ group_iter.id }}" >{{ group_iter.title }}</option>
+						{% endif %}
+					{% endfor %}
+				</select>
+			</div>
+			<br>
+		{% endif %}
+	{% endfor %}
+		
+		
+
+
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required"></span>Themen</label>  
+
+	{# checking if group is included in data.groups does for some reason not work in Jinja, hence the id check, again with an invisible label #}
+	{% set group_ids = [] %}
+	{% for group in data.groups %}
+		<label class="control-label" for="field-group" style="display:none"><span title="abc" class="control-required"></span>{{ group_ids.append(group.id) }}</label>
+	{%endfor %}
+
+	{% for group in h.get_allowable_children_groups('topics') %}
+		{% if group.id in group_ids %}
+			<label class="checkbox" for="field-group-{{ loop.index0 + 100 }}">
+				<input id="field-group-{{ loop.index0 + 100 }}" type="checkbox" name="groups__{{ loop.index0 + 100 }}__id" value="{{ group.id }}" checked=true/>{{ group.title }}
+			</label>
+		{% else %}
+			<label class="checkbox" for="field-group-{{ loop.index0 + 100 }}" style="display:none">
+				<input id="field-group-{{ loop.index0 + 100 }}" type="checkbox" name="groups__{{ loop.index0 + 100 }}__id" value="{{ group.id }}"/>{{ group.title }}
+			</label>		
+		{% endif %}
+	{%endfor%}
+
+	<div class="controls">
+		<select id="field-group_2" name="groups__2__id" data-module="autocomplete" onclick="show_checkboxes(this)">
+			<option value=""selected="selected">Bitte wählen Sie</option>
+				{% for group in h.get_allowable_children_groups('topics') %}
+					{% set existing_group_id = group.id %}
+					{% if group.id not in group_ids %}
+						<option value="{{ group.id }}" >{{ group.title }}</option>
+					{% endif %}
+				{% endfor %}
+		</select>
+	</div>
+	<br>
+
+
+<!--
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required"> </span>Modellregionen</label>
+
+	{# checking if group is included in data.groups does for some reason not work in Jinja, hence the id check, again with an invisible label #}
+	{% set group_ids = [] %}
+	{% for group in data.groups %}
+		<label class="control-label" for="field-group" style="display:none"><span title="abc" class="control-required"></span>{{ group_ids.append(group.id) }}</label>
+	{%endfor %}
+	
+	{% for group in h.get_allowable_children_groups('model-regions') %}
+		{% if group.id in group_ids %}
+			<label class="checkbox" for="field-group-{{ loop.index0 + 1000 }}">
+				<input id="field-group-{{ loop.index0 + 1000 }}" type="checkbox" name="groups__{{ loop.index0 + 1000 }}__id" value="{{ group.id }}" checked=true/>{{ group.title }}
+			</label>
+		{% else %}
+			<label class="checkbox" for="field-group-{{ loop.index0 + 1000 }}" style="display:none">
+				<input id="field-group-{{ loop.index0 + 1000 }}" type="checkbox" name="groups__{{ loop.index0 + 1000 }}__id" value="{{ group.id }}"/>{{ group.title }}
+			</label>
+		{% endif %}
+	{% endfor %}
+
+	<div class="controls">
+		<select id="field-group_3" name="groups__1__id" data-module="autocomplete" onclick="show_checkboxes(this)">
+			<option value=""selected="selected">Bitte wählen Sie</option>
+				{% for group in h.get_allowable_children_groups('model-regions')  %}
+					{% set existing_group_id = group.id %}
+					{% if group.id not in group_ids %}
+						<option value="{{ group.id }}" >{{ group.title }}</option>
+					{% endif %}
+				{% endfor %}
+		</select>
+	</div>
+	</ol>
+	<br>
+-->
+	
+	<span class="info-block info-block-small">
+		<i class="fa fa-info-circle"></i>{% trans %}Die 'Hauptkategorie' ist ein Pflichtfeld. Um einen besseren Überblick über die gesamten Gruppen zu haben, sehen Sie sich diese <a href="http://129.187.38.46/group/">Seite</a> an.{% endtrans %}
+	</span>
+	<hr>
+
+		
+{% endif %}
+
+
+
+
+
+{% if not data.groups %}
+
+
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required">* </span>Hauptkategorien</label>
+	<div class="controls">
+		<select id="field-group" name="groups__0__id" data-module="autocomplete">
+			<!--option value=""selected="selected">Bitte wählen Sie</option-->
+			{% for group in h.get_allowable_children_groups('main-categories')  %}
+				{% set existing_group_id = group.id %}
+					<option value="{{ group.id }}">{{ group.title }}</option>
+			{% endfor %}
+		</select>
+	</div>
+	<br>
+	
+
+
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required"></span>Themen</label>
+	{% for group in h.get_allowable_children_groups('topics') %}
+		<label class="checkbox" for="field-group-{{ loop.index0 + 100 }}" style="display:none">
+			<input id="field-group-{{ loop.index0 + 100 }}" type="checkbox" name="groups__{{ loop.index0 + 100 }}__id" value="{{ group.id }}"/>{{ group.title }}
+		</label>
+	{% endfor %}
+
+	<div class="controls">
+		<select id="field-group" name="groups__2__id" data-module="autocomplete" onclick="show_checkboxes(this)">
+			<option value=""selected="selected">Bitte wählen Sie</option>
+			{% for group in h.get_allowable_children_groups('topics')  %}
+				{% set existing_group_id = group.id %}
+				<option value="{{ group.id }}">{{ group.title }}</option>
+			{% endfor %}
+			<option value="">Keine</option>
+		</select>
+	</div>
+	<br>
+
+
+<!--
+	<label class="control-label" for="field-group"><span title="This field is required" class="control-required"> </span>Modellregionen</label>
+	{% for group in h.get_allowable_children_groups('model-regions') %}
+		<label class="checkbox" for="field-group-{{ loop.index0 + 1000 }}" style="display:none">
+			<input id="field-group-{{ loop.index0 + 1000 }}" type="checkbox" name="groups__{{ loop.index0 + 1000 }}__id" value="{{ group.id }}"/>{{ group.title }}
+		</label>
+	{% endfor %}
+
+	<div class="controls">
+		<select id="field-group" name="groups__1__id" data-module="autocomplete" onclick="show_checkboxes(this)">
+			<option value=""selected="selected">Bitte wählen Sie</option>
+			{% for group in h.get_allowable_children_groups('model-regions')  %}
+				{% set existing_group_id = group.id %}
+				<option value="{{ group.id }}">{{ group.title }}</option>
+			{% endfor %}
+			<option value="">Keine</option>
+		</select>
+	</div>
+-->
+
+	</ol>
+
+<div class="form-group">
+	<div class="info-block">
+		<i class="fa fa-info-circle"></i>{% trans %}
+Jeder Katalogeintrag ist genau einer "Hauptkategorie" zugeordnet. Die Zuordnung zu den Gruppen "Themen" und "Modellregionen" ist optional, hier können auch mehr als eine Gruppe ausgewählt werden. Um einen besseren Überblick über die gesamten Gruppen zu haben, sehen Sie sich diese <a href="/group/">Seite</a> an.{% endtrans %}
+	</div>
+</div>
+	<hr/>
+	
+	
+{% endif %}

--- a/ckanext/grouphierarchy/templates/scheming/form_snippets/spatial.html
+++ b/ckanext/grouphierarchy/templates/scheming/form_snippets/spatial.html
@@ -1,0 +1,133 @@
+
+{#
+An input widget for polygons, such as the ckanext-spatial "spatial" field for
+the dataset extent.
+
+This widget retains the plain text input which accepts a valid GeoJSON
+geometry, and also adds a map on which one can simply draw the dataset extent.
+
+Providing alternative map input has two motivations:
+- Drawing is achievable, pasting a valid GeoJSON geometry will post a challenge
+to many non-GIS-trained users
+- Users will have additional, silent expert knowledge on the real extent
+of their dataset.
+
+This form snippet depends on a custom branch of ckanext-spatial, which
+provides (and is the appropriate home for) the JavaScript functions to
+provide an editable map.
+
+#}
+
+{% import 'macros/form.html' as form %}
+{% with
+    name=field.field_name,
+    id='field-' + field.field_name,
+    label=h.scheming_language_text(field.label),
+    placeholder=h.scheming_language_text(field.form_placeholder),
+    value=data[field.field_name],
+    error=errors[field.field_name],
+    classes=['control-medium'],
+    is_required=h.scheming_field_required(field)
+%}
+
+  {% call form.input_block(id, label, error, classes, is_required=is_required) %}
+
+    {% set map_config = h.get_common_map_config() %}
+    <div class="dataset-map"
+        data-module="spatial-form"
+        data-input_id="{{ id }}"
+        data-extent="{{ value }}"
+        data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"
+        data-module-map_config="{{ h.dump_json(map_config) }}">
+      <div id="dataset-map-container"></div>
+    </div>
+    <p></p><!-- a little trailing space -->
+
+
+    <!-- choose predefined, on change update input {{ id }} -->
+    <script type="text/javascript">
+    /* Set the value of textarea #{{ id }} to the value of select menu #select-{{ id }}
+     * IDs are hard-coded, as this script lives at the same level as the IDs are defined
+     */
+    function updateInput(){
+        //$("#{{ id }}").val($("#select-{{ id }}").val());
+    }
+    </script>
+
+
+<select id="select-{{ id }}" onchange="updateInput()">
+       {# <option value="">-- Select pre-defined extent --</option> #}
+       <option value="">-- Vordefinierten Raumbereich auswählen --</option>
+	   {% snippet 'scheming/form_snippets/spatial_snippets/spatial_templates.html' %}
+      {% for c in field.choices %}
+        <option value="{{ c.value | replace("u'","\"") | replace("'","\"") | empty_and_escape }}">{{ c.label }}</option>
+      {% endfor %}
+    </select>
+
+
+    <!-- TODO this should be an autocompleting select box like tags,
+         polling from a user-defined custom vocabulary of label/geojson pairs,
+         defined in the dataset schema as e.g. field.vocabulary.
+         Also, this snippet should be moved into ckanext-spatial's form_spatial.js so the data binding JS
+         is in one place.
+         NOTE The value expects "real strings", not u'nonsense'. For demonstration purposes,
+         let's sanitize the JSON here, so valid JSON goes into the dataset schema and we won't need
+         to touch unicode/string handling in the pylons parts, which could cause more headache than it prevents.
+    -->
+    <!-- /choose predefined -->
+
+    <!-- TODO Show all attached GeoJSON resources on map (ajax load). This helps
+         the user to draw a bounding polygon around existing spatial features, but also
+         captures user's silent knowledge about the real dataset extent.
+
+    {{ form.info(text="Draw and edit the dataset extent as rectangles and/or polygons on the map,
+       or select a pre-defined area from the menu,
+       or paste a GeoJSON Polygon or Multipolygon geometry below", inline=false) }}-->
+
+       {{ form.info(text="Zeichnen und bearbeiten Sie die Ausdehnung des Datensatzes als Punkt, oder Polygon auf der Karte (nicht beides gleichzeitig),
+		oder wählen Sie einen vordefinierten Raumbereich aus dem Menü, oder fügen Sie eine GeoJSON Polygon- oder Multipolygon-Geometrie ein. Anhand der Ausdehnung kann später nach Katalogeinträgen gesucht werden.", inline=false) }}
+
+    <!-- Textarea #{{ id }} accepts a Polygon GeoJSON geometry.
+         The map updates this input on drawing/editing/deleting shapes,
+         the select menu updates this input on selecting options.
+    -->
+    <textarea id="{{ id }}" type="{{ type }}" name="{{ name }}"
+        placeholder="{{ placeholder }}" rows=10 style="width:100%;"
+    >{{ value | empty_and_escape }}</textarea>
+
+
+<script>
+
+	// Run when the page is fully loaded
+	window.onload=function(){
+
+		// get the input field and the submit button
+		var spatial_input = document.getElementById("field-spatial");
+		var submit_button = document.querySelector(".btn.btn-primary");
+
+		// execute this code when the submit button is pressed
+		submit_button.onclick=function(){
+
+			// get the geojson string
+			var coords = spatial_input.value;
+
+			// if some geojson object is present
+			if(coords.includes("MultiPolygon")){
+
+
+				// if 2 square brackets are included but not 4 square brackets it is a Point and not a MultiPolygon
+				if(coords.includes("\[\[") && coords.includes("\]\]") && !coords.includes("\[\[\[\[") && !coords.includes("\]\]\]\]")){
+
+					// replace in the string and change it in the input field
+					coords = coords.replace("MultiPolygon", "Point");
+					coords = coords.replace("\[\[", "\[");
+					coords = coords.replace("\]\]", "\]");
+					spatial_input.value = coords;
+				}
+			}
+		}
+	}
+</script>
+
+  {% endcall %}
+{% endwith %}


### PR DESCRIPTION
I added this to load the spatial search widget in on the dataset search page (`search.html`).

Some questions before we merge this:
 
- How will this behave if `ckanext-spatial` is not available?
- Will it cause an error or will it just be ignored?
- Is there a way to make loading the snippet optional (only if `ckanext-spatial`) is present?
  - If yes, we could avoid having `ckanext-spatial` as a dependency, right?